### PR TITLE
ECS-6549 Build and release IOCs for Rocky 9

### DIFF
--- a/RELEASE_SITE
+++ b/RELEASE_SITE
@@ -1,10 +1,10 @@
 BASE_MODULE_VERSION = R7.0.3.1-2.0
-EPICS_SITE_TOP      = /cds/group/pcds/epics
-EPICS_MODULES       = $(EPICS_SITE_TOP)/$(BASE_MODULE_VERSION)/modules
+EPICS_SITE_TOP = /cds/group/pcds/epics
+EPICS_MODULES = $(EPICS_SITE_TOP)/$(BASE_MODULE_VERSION)/modules
 ifeq ($(origin EPICS_HOST_ARCH), undefined)
-EPICS_HOST_ARCH     := $(shell $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)/startup/EpicsHostArch)
+EPICS_HOST_ARCH := $(shell $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)/startup/EpicsHostArch)
 endif
-PSPKG_ROOT          = /cds/group/pcds/pkg_mgr
+PSPKG_ROOT = /cds/group/pcds/pkg_mgr
 
 $(info Setting BASE_MODULE_VERSION to $(BASE_MODULE_VERSION) in $(lastword $(MAKEFILE_LIST)))
 

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -6,10 +6,10 @@ include $(TOP)/RELEASE_SITE
 # Define the version of modules needed by
 # IOC apps or other Support apps
 # ===============================================================
-ASYN_MODULE_VERSION          = R4.39-1.0.0
-AUTOSAVE_MODULE_VERSION      = R5.8-2.1.0
-IOCADMIN_MODULE_VERSION      = R3.1.16-1.3.2
-STREAMDEVICE_MODULE_VERSION  = R2.8.9-1.2.0
+ASYN_MODULE_VERSION = R4.39-1.0.2
+AUTOSAVE_MODULE_VERSION = R5.11-2.0.0
+IOCADMIN_MODULE_VERSION = R3.1.16-1.4.0
+STREAMDEVICE_MODULE_VERSION = R2.8.9-1.2.2
 
 # ============================================================
 # External Support module path definitions


### PR DESCRIPTION
Updated configuration files for Rocky 9 migration. Due date: 10/15/2025

Test IOC output:
```
(pcds-6.0.1) janeliu@psbuild-rocky9-01:iocs $ telnet ctl-tst-dev-03 30001
Trying 172.21.148.78...
Connected to ctl-tst-dev-03.
Escape character is '^]'.
@@@ Welcome to procServ (procServ Process Server 2.9.0-1.1.0)
@@@ Use ^X to kill the child, auto restart mode is ON, use ^T to toggle auto restart
@@@ procServ server PID: 2003881
@@@ Server startup directory: /tmp
@@@ Child startup directory: /tmp
@@@ Child "ioc-tst-tem-mspace" started as: startProc
@@@ Child log file: unable to open log file /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/ioc.log
@@@ Child "ioc-tst-tem-mspace" PID: 2004805
@@@ procServ server started at: Tue Oct 21 09:50:09 2025
@@@ Child "ioc-tst-tem-mspace" started at: Tue Oct 21 09:50:40 2025
@@@ 0 user(s) and 0 logger(s) connected (plus you)
@@@ Current time: Tue Oct 21 09:51:42 2025
@@@ Child process is shutting down, a new one will be restarted shortly
@@@ ^R or ^X restarts the child, ^Q quits the server

@@@ @@@ @@@ @@@ @@@
@@@ Received a sigChild for process 2004805. The process was killed by signal 9
@@@ Restarting child "ioc-tst-tem-mspace"
@@@    (as startProc)
@@@ The PID of new child "ioc-tst-tem-mspace" is: 2006437
@@@ @@@ @@@ @@@ @@@
#!/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock/bin/rhel9-x86_64/TEM_PhaseLock
epicsEnvSet( "IOCNAME",   "ioc-tst-tem-mspace" )
epicsEnvSet( "ENGINEER",  "Jane Liu (janeliu-slac)" )
epicsEnvSet( "LOCATION",  "TST" )
epicsEnvSet( "IOCSH_PS1", "ioc-tst-tem-mspace> " )
epicsEnvSet( "IOC_PV",    "IOC:TST:TEM:01" )
epicsEnvSet( "IOCTOP",    "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock" )
epicsEnvSet( "STREAM_PROTOCOL_PATH", "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock/app/srcProtocol" )
< envPaths
epicsEnvSet("IOC","ioc-tst-tem-mspace")
epicsEnvSet("TOP","/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock")
epicsEnvSet("EPICS_SITE_TOP","/cds/group/pcds/epics")
epicsEnvSet("EPICS_MODULES","/cds/group/pcds/epics/R7.0.3.1-2.0/modules")
epicsEnvSet("PSPKG_ROOT","/cds/group/pcds/pkg_mgr")
epicsEnvSet("ASYN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/asyn/R4.39-1.0.2")
epicsEnvSet("AUTOSAVE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1")
epicsEnvSet("IOCADMIN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0")
epicsEnvSet("STREAMDEVICE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/streamdevice/R2.8.9-1.2.2")
epicsEnvSet("EPICS_BASE","/cds/group/pcds/epics/base/R7.0.3.1-2.0")
epicsEnvSet("TOP", "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock/children/build")
cd("/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock")
# Run common startup commands for linux soft IOC's
< /reg/d/iocCommon/All/pre_linux.cmd
#==============================================================
#
#  Abs:  Soft IOC pre-startup initialization (Production)
#
#  Name: pre_linux.cmd
#
#  Facility: LCLS Controls
#
#  Auth: 27-Jul-2009, Bruce Hill (bhill)
#  Rev:  dd-mmm-yyyy, Reviewer's Name (USERNAME)
#                       Based on soft_pre_st.cmd from LCLS
#  Mod:
#       dd-mmm-yyyy, Firstname Lastname (USERNAME):
#         comment
#
#==============================================================
#
# Time...
epicsEnvSet("EPICS_TS_NTP_INET","psntp.slac.stanford.edu")
# iocLogClient...
epicsEnvSet("EPICS_IOC_LOG_FILE_LIMIT","1000000")
epicsEnvSet("EPICS_IOC_LOG_FILE_COMMAND","")
# iocLogClient: Send log messages to logstash:
epicsEnvSet("EPICS_IOC_LOG_INET", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_IOC_LOG_PORT", "7004")
# The following prefix is *required* for logstash to know which IOC is sending
# the message.  This *cannot* be modified without changes to the logstash
# configuration.
iocLogPrefix("IOC=ioc-tst-tem-mspace ")
# caPutLog: Send caPutLog messages to logstash:
epicsEnvSet("EPICS_CAPUTLOG_HOST", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_CAPUTLOG_PORT", "7011")
epicsEnvSet("EPICS_CA_PUT_LOG_ADDR", "ctl-logsrv01.pcdsn:7011")
# TODO: Need a way to conditionally set these based on the host so ioc-xcs-misc1 and others don't send CA traffic over fez
# Channel Access...
epicsEnvSet("EPICS_CA_ADDR_LIST","")
epicsEnvSet("EPICS_CA_REPEATER_PORT","5065")
epicsEnvSet("EPICS_CA_SERVER_PORT","5064")
epicsEnvSet("EPICS_CA_CONN_TMO","10.0")
epicsEnvSet("EPICS_CA_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_SEARCH_PERIOD","60.0")
epicsEnvSet("EPICS_CA_AUTO_ADDR_LIST","YES")
epicsEnvSet("EPICS_CAS_INTF_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_AUTO_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_SERVER_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", "4000000")
# Let's add this for pvaccess support.  If it's not compiled in, it can't hurt,
# and if you really want it off, you can do that in the st.cmd after including
# this.
epicsEnvSet( "EPICS_PVA_AUTO_ADDR_LIST",         "TRUE" )
epicsEnvSet( "EPICS_PVAS_AUTO_BEACON_ADDR_LIST", "TRUE" )
# Enable ioc error logging
setIocLogDisable 0
## Register all support components
dbLoadDatabase( "dbd/TEM_PhaseLock.dbd" )
TEM_PhaseLock_registerRecordDeviceDriver(pdbbase)
Warning: IOC is booting with TOP = "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock/children/build"
          but was built with TOP = "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock"
## Set up IOC/hardware links -- LAN connection
##############################################################
drvAsynSerialPortConfigure( "bus0", "/dev/usbTEM0", 0, 0, 0 )
2025/10/21 09:51:44.826 bus0 -1 autoConnect could not connect: /dev/usbTEM0 Can't open  No such file or directory
asynSetTraceIOMask( "bus0", 0, 0x1 ) # logging for normal operation
## Load record instances
dbLoadRecords( "db/iocSoft.db", "IOC=IOC:TST:TEM:01")
dbLoadRecords( "db/save_restoreStatus.db", "P=IOC:TST:TEM:01:")
dbLoadRecords( "db/TEM_PhaseLock.db", "DEVICE=TST:TEM:01, PORT=bus0" )
## Setup autosave
set_savefile_path( "/reg/d/iocData/ioc-tst-tem-mspace/autosave" )
set_requestfile_path( "/cds/home/j/janeliu/git/iocs/built/ioc-common-TEM_PhaseLock/children/build/autosave" )
# Also look in the iocData autosave folder for auto generated req files
set_requestfile_path( "/reg/d/iocData/ioc-tst-tem-mspace/autosave" )
save_restoreSet_status_prefix( "IOC:TST:TEM:01:" )
save_restoreSet_IncompleteSetsOk( 1 )
save_restoreSet_DatedBackupFiles( 1 )
set_pass0_restoreFile( "autoSettings.sav" )
set_pass0_restoreFile( "ioc-tst-tem-mspace.sav" )
# Initialize the IOC and start processing records
iocInit()
Starting iocInit
############################################################################
## EPICS R7.0.3.1-2.0.1
## EPICS Base built Oct 17 2024
############################################################################
save_restore: Can't open file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav'.
save_restore: Trying backup file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.savB'
save_restore: Can't open file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.savB'.
save_restore: Can't figure out which seq file is most recent,
save_restore: so I'm just going to start with '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav0'.
save_restore: Trying backup file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav0'
save_restore: Can't open file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav0'.
save_restore: Trying backup file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav1'
save_restore: Can't open file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav1'.
save_restore: Trying backup file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav2'
save_restore: Can't open file '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav2'.
save_restore: Can't find a file to restore from...
save_restore: ...last tried '/reg/d/iocData/ioc-tst-tem-mspace/autosave/ioc-tst-tem-mspace.sav2'. I give up.
save_restore: **********************************

save_restore: Can't open save file.2025/10/21 09:51:45.463456 _main_ TST:TEM:01:REG_STATE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463468 _main_ TST:TEM:01:REG_STATE: Can't start @init handler
2025/10/21 09:51:45.463473 _main_ TST:TEM:01:REG_STATE: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_STATE ao: init_record

2025/10/21 09:51:45.463503 _main_ TST:TEM:01:REG_A_STATE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463509 _main_ TST:TEM:01:REG_A_STATE: Can't start @init handler
2025/10/21 09:51:45.463516 _main_ TST:TEM:01:REG_A_STATE: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_A_STATE ao: init_record

2025/10/21 09:51:45.463541 _main_ TST:TEM:01:REG_B_STATE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463546 _main_ TST:TEM:01:REG_B_STATE: Can't start @init handler
2025/10/21 09:51:45.463551 _main_ TST:TEM:01:REG_B_STATE: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_B_STATE ao: init_record

2025/10/21 09:51:45.463575 _main_ TST:TEM:01:REG_A_OFFSET lockRequest: port bus0 not connected
2025/10/21 09:51:45.463580 _main_ TST:TEM:01:REG_A_OFFSET: Can't start @init handler
2025/10/21 09:51:45.463584 _main_ TST:TEM:01:REG_A_OFFSET: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_A_OFFSET ao: init_record

2025/10/21 09:51:45.463611 _main_ TST:TEM:01:REG_B_OFFSET lockRequest: port bus0 not connected
2025/10/21 09:51:45.463617 _main_ TST:TEM:01:REG_B_OFFSET: Can't start @init handler
2025/10/21 09:51:45.463622 _main_ TST:TEM:01:REG_B_OFFSET: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_B_OFFSET ao: init_record

2025/10/21 09:51:45.463644 _main_ TST:TEM:01:REG_A_PGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463649 _main_ TST:TEM:01:REG_A_PGAIN: Can't start @init handler
2025/10/21 09:51:45.463654 _main_ TST:TEM:01:REG_A_PGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_A_PGAIN ao: init_record

2025/10/21 09:51:45.463673 _main_ TST:TEM:01:REG_B_PGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463678 _main_ TST:TEM:01:REG_B_PGAIN: Can't start @init handler
2025/10/21 09:51:45.463683 _main_ TST:TEM:01:REG_B_PGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_B_PGAIN ao: init_record

2025/10/21 09:51:45.463705 _main_ TST:TEM:01:REG_A_IGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463710 _main_ TST:TEM:01:REG_A_IGAIN: Can't start @init handler
2025/10/21 09:51:45.463715 _main_ TST:TEM:01:REG_A_IGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_A_IGAIN ao: init_record

2025/10/21 09:51:45.463739 _main_ TST:TEM:01:REG_B_IGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463744 _main_ TST:TEM:01:REG_B_IGAIN: Can't start @init handler
2025/10/21 09:51:45.463748 _main_ TST:TEM:01:REG_B_IGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_B_IGAIN ao: init_record

2025/10/21 09:51:45.463770 _main_ TST:TEM:01:REG_A_DGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463775 _main_ TST:TEM:01:REG_A_DGAIN: Can't start @init handler
2025/10/21 09:51:45.463780 _main_ TST:TEM:01:REG_A_DGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_A_DGAIN ao: init_record

2025/10/21 09:51:45.463801 _main_ TST:TEM:01:REG_B_DGAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.463806 _main_ TST:TEM:01:REG_B_DGAIN: Can't start @init handler
2025/10/21 09:51:45.463811 _main_ TST:TEM:01:REG_B_DGAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_B_DGAIN ao: init_record

2025/10/21 09:51:45.463830 _main_ TST:TEM:01:REG_OUT_A_RANGE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463835 _main_ TST:TEM:01:REG_OUT_A_RANGE: Can't start @init handler
2025/10/21 09:51:45.463840 _main_ TST:TEM:01:REG_OUT_A_RANGE: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_OUT_A_RANGE ao: init_record

2025/10/21 09:51:45.463873 _main_ TST:TEM:01:REG_OUT_B_RANGE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463878 _main_ TST:TEM:01:REG_OUT_B_RANGE: Can't start @init handler
2025/10/21 09:51:45.463882 _main_ TST:TEM:01:REG_OUT_B_RANGE: Record initialization failed
Error (514,514) PV: TST:TEM:01:REG_OUT_B_RANGE ao: init_record

2025/10/21 09:51:45.463904 _main_ TST:TEM:01:ERR_SCALE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463909 _main_ TST:TEM:01:ERR_SCALE: Can't start @init handler
2025/10/21 09:51:45.463914 _main_ TST:TEM:01:ERR_SCALE: Record initialization failed
Error (514,514) PV: TST:TEM:01:ERR_SCALE ao: init_record

2025/10/21 09:51:45.463938 _main_ TST:TEM:01:SCAN_ENABLE lockRequest: port bus0 not connected
2025/10/21 09:51:45.463943 _main_ TST:TEM:01:SCAN_ENABLE: Can't start @init handler
2025/10/21 09:51:45.463948 _main_ TST:TEM:01:SCAN_ENABLE: Record initialization failed
Error (514,514) PV: TST:TEM:01:SCAN_ENABLE ao: init_record

2025/10/21 09:51:45.463970 _main_ TST:TEM:01:SCAN_OFFSET lockRequest: port bus0 not connected
2025/10/21 09:51:45.463975 _main_ TST:TEM:01:SCAN_OFFSET: Can't start @init handler
2025/10/21 09:51:45.463980 _main_ TST:TEM:01:SCAN_OFFSET: Record initialization failed
Error (514,514) PV: TST:TEM:01:SCAN_OFFSET ao: init_record

2025/10/21 09:51:45.464002 _main_ TST:TEM:01:QI_OFFSET lockRequest: port bus0 not connected
2025/10/21 09:51:45.464007 _main_ TST:TEM:01:QI_OFFSET: Can't start @init handler
2025/10/21 09:51:45.464012 _main_ TST:TEM:01:QI_OFFSET: Record initialization failed
Error (514,514) PV: TST:TEM:01:QI_OFFSET ao: init_record

2025/10/21 09:51:45.464034 _main_ TST:TEM:01:QI_ACTIVE lockRequest: port bus0 not connected
2025/10/21 09:51:45.464039 _main_ TST:TEM:01:QI_ACTIVE: Can't start @init handler
2025/10/21 09:51:45.464043 _main_ TST:TEM:01:QI_ACTIVE: Record initialization failed
Error (514,514) PV: TST:TEM:01:QI_ACTIVE ao: init_record

2025/10/21 09:51:45.464065 _main_ TST:TEM:01:QI_GAIN lockRequest: port bus0 not connected
2025/10/21 09:51:45.464070 _main_ TST:TEM:01:QI_GAIN: Can't start @init handler
2025/10/21 09:51:45.464075 _main_ TST:TEM:01:QI_GAIN: Record initialization failed
Error (514,514) PV: TST:TEM:01:QI_GAIN ao: init_record

Successfully locked memory using mlockAll
iocRun: All initialization complete
# Create autosave files from info directives
makeAutosaveFileFromDbInfo( "/reg/d/iocData/ioc-tst-tem-mspace/autosave/autoSettings.req", "autosaveFields" )
# Start autosave backups
create_monitor_set( "autoSettings.req", 5, "" )
create_monitor_set( "ioc-tst-tem-mspace.req", 5, "" )
# All IOCs should dump some common info after initial startup.
< /reg/d/iocCommon/All/post_linux.cmd
# Let's Get EPICS version:
iocshCmd("coreRelease > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.epicsVersion")
# Let's Get EPICS environment:
iocshCmd("epicsEnvShow > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.epicsEnvShow")
# Dump a list of all PVs to a file on the Boot Server:
# The pvs name will be written to a file along with its record type.
# The location on the boot server follows:
# ${IOC_DATA}/${IOC}/iocInfo
iocshCmd("dbl '' RTYP > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.pvlist")
iocshCmd("dbl '' DTYP > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.DTYP")
# Let's get the hardware info from the IOC to the boot server
iocshCmd("dbhcr > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.dbhcr")
iocshCmd("dbior > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.dbior")
# Let's get alarm ready Data
iocshCmd("dbl '' 'RTYP DTYP SCAN HHSV HSV LSV LLSV OSV ZSV HYST HIHI LOLO HIGH LOW' >/reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.pvAlarm")
# Let's get input/output data
iocshCmd("dbl '' 'RTYP DTYP SCAN INP OUT OMSL DOL TSE' >/reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.pvIO")
# Let's get scaling info
iocshCmd("dbl '' 'RTYP DTYP SCAN HOPR LOPR DRVH DRVL EGUF EGUL LINR AOFF ASLO ESLO' >/reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.pvScale")
# Let's get the remaining interesting PV fields:
iocshCmd("dbl '' 'RTYP DTYP SCAN ASG IOVA IVOV ADEL MDEL SMOO' >/reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.pvMisc")
# CA report
iocshCmd("casr(2) > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.casr")
# Db CA Connections
iocshCmd("dbcar(0,1) > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.dbcar")
# dbDumpRecord report
iocshCmd("dbDumpRecord > /reg/d/iocData/ioc-tst-tem-mspace/iocInfo/IOC.dbDumpRecord")
ioc-tst-tem-mspace.sav: 0 of 0 PV's connected
autoSettings.sav: 21 of 21 PV's connected
# Post Startup Complete, the IRMIS crawler appreciates your cooperation.
ioc-tst-tem-mspace>
```