### PR TITLE
ENH: Add new registers and calculations, and cleanup

### DIFF
--- a/app/Db/TEM_PhaseLock.archive
+++ b/app/Db/TEM_PhaseLock.archive
@@ -51,6 +51,7 @@ $(BASE):SCAN_ENABLE                     1 monitor
 $(BASE):SCAN_OFFSET_RBCK                1 monitor
 $(BASE):SCAN_OFFSET                     1 monitor
 $(BASE):QI_OFFSET_RBCK                  1 monitor
+$(BASE):QI_OFFSET_RBCK_PS               1 monitor
 $(BASE):QI_OFFSET                       1 monitor
 $(BASE):QI_ACTIVE_RBCK                  1 monitor
 $(BASE):QI_ACTIVE                       1 monitor

--- a/app/Db/TEM_PhaseLock.archive
+++ b/app/Db/TEM_PhaseLock.archive
@@ -11,6 +11,8 @@ $(BASE):PHASE_ERR                       1 monitor
 $(BASE):SP_PHASE                        1 monitor
 $(BASE):REG_OUT_A                       1 monitor
 $(BASE):REG_OUT_B                       1 monitor
+$(BASE):OUTPUT_A                        1 monitor
+$(BASE):OUTPUT_B                        1 monitor
 $(BASE):REG_A_LOCKED                    1 monitor
 $(BASE):REG_B_LOCKED                    1 monitor
 $(BASE):IN_CLIP                         1 monitor

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -130,7 +130,7 @@ record(ai, "$(DEVICE):OUTPUT_A") {
   field(DESC, "Output A")
   field(DTYP, "stream")
   field(INP,  "@TEM_PhaseLock.proto GET_OUT_A $(PORT)")
-  field(EGU,  "V")
+  field(EGU,  "mV")
   field(PREC, "2")
   field(FLNK, "$(DEVICE):OUTPUT_B")
   info(autosaveFields, "EGU")
@@ -140,7 +140,7 @@ record(ai, "$(DEVICE):OUTPUT_B") {
   field(DESC, "Output B")
   field(DTYP, "stream")
   field(INP,  "@TEM_PhaseLock.proto GET_OUT_B $(PORT)")
-  field(EGU,  "V")
+  field(EGU,  "mV")
   field(PREC, "2")
   info(autosaveFields, "EGU")
 }

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -376,6 +376,7 @@ record(calc, "$(DEVICE):QI_OFFSET_RBCK_PS") {
   # ( QI_OFFSET mdeg / 360000 mdeg/cycle) * (1 / QI Gain kHz) * 1000000000 kHz/GHz = QI Offset (ps)  
   field(CALC, "(A/360000)*(1/B)*1000000000") 
   field(EGU,  "ps")
+  field(PREC, "2")
   info(autosaveFields, "EGU")
 }
 

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -373,8 +373,8 @@ record(calc, "$(DEVICE):QI_OFFSET_RBCK_PS") {
   field(DESC, "QI Offset, in ps")
   field(INPA, "$(DEVICE):QI_OFFSET_RBCK CP") # millidegrees
   field(INPB, "$(DEVICE):QI_GAIN_RBCK CP")   # kHz
-  # ( QI_OFFSET mdeg / 360000 mdeg/cycle) * (1000 / QI Gain kHz) = QI Offset (ps)  
-  field(CALC, "(A/360000)*(1000/B)") 
+  # ( QI_OFFSET mdeg / 360000 mdeg/cycle) * (1 / QI Gain kHz) * 1000000000 kHz/GHz = QI Offset (ps)  
+  field(CALC, "(A/360000)*(1/B)*1000000000") 
   field(EGU,  "ps")
   info(autosaveFields, "EGU")
 }

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -123,6 +123,26 @@ record(ai, "$(DEVICE):REG_B_STATE_RBCK") {
   field(DTYP, "stream")
   field(SCAN, "1 second")
   field(INP,  "@TEM_PhaseLock.proto GET_REG_B $(PORT)")
+  field(FLNK, "$(DEVICE):OUTPUT_A")
+}
+
+record(ai, "$(DEVICE):OUTPUT_A") {
+  field(DESC, "Output A")
+  field(DTYP, "stream")
+  field(INP,  "@TEM_PhaseLock.proto GET_OUT_A $(PORT)")
+  field(EGU,  "V")
+  field(PREC, "2")
+  field(FLNK, "$(DEVICE):OUTPUT_B")
+  info(autosaveFields, "EGU")
+}
+
+record(ai, "$(DEVICE):OUTPUT_B") {
+  field(DESC, "Output B")
+  field(DTYP, "stream")
+  field(INP,  "@TEM_PhaseLock.proto GET_OUT_B $(PORT)")
+  field(EGU,  "V")
+  field(PREC, "2")
+  info(autosaveFields, "EGU")
 }
 
 record(ao, "$(DEVICE):REG_B_STATE") {

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -369,6 +369,16 @@ record(ai, "$(DEVICE):QI_OFFSET_RBCK") {
   info(autosaveFields, "EGU")
 }
 
+record(calc, "$(DEVICE):QI_OFFSET_RBCK_PS") {
+  field(DESC, "QI Offset, in ps")
+  field(INPA, "$(DEVICE):QI_OFFSET_RBCK CP") # millidegrees
+  field(INPB, "$(DEVICE):QI_GAIN_RBCK CP")   # kHz
+  # ( QI_OFFSET mdeg / 360000 mdeg/cycle) * (1000 / QI Gain kHz) = QI Offset (ps)  
+  field(CALC, "(A/360000)*(1000/B)") 
+  field(EGU,  "ps")
+  info(autosaveFields, "EGU")
+}
+
 record(ao, "$(DEVICE):QI_OFFSET") {
   field(DESC, "QI Offset")
   field(DTYP, "stream")
@@ -397,7 +407,7 @@ record(ai, "$(DEVICE):QI_GAIN_RBCK") {
   field(DTYP, "stream")
   field(SCAN, "1 second")
   field(INP,  "@TEM_PhaseLock.proto GET_QI_GAIN $(PORT)")
-  field(EGU,  "Hz")
+  field(EGU,  "kHz")
   info(autosaveFields, "EGU")
 }
 
@@ -406,7 +416,7 @@ record(ao, "$(DEVICE):QI_GAIN") {
   field(DTYP, "stream")
   field(OUT,  "@TEM_PhaseLock.proto SET_QI_GAIN $(PORT)")
   field(FLNK, "$(DEVICE):QI_GAIN_RBCK")
-  field(EGU,  "Hz")
+  field(EGU,  "kHz")
   info(autosaveFields, "EGU")
 }
 

--- a/app/Db/TEM_PhaseLock.db
+++ b/app/Db/TEM_PhaseLock.db
@@ -12,6 +12,13 @@ record(stringin, "$(DEVICE):BUILD") {
   field(PINI, "YES")
 }
 
+record(stringin, "$(DEVICE):FPGAFW") {
+  field(DESC, "FPGA FW version")
+  field(DTYP, "stream")
+  field(INP, "@TEM_PhaseLock.proto GET_FPGA $(PORT)")
+  field(PINI, "YES")
+}
+
 record(ai, "$(DEVICE):TGT_TIME") {
   field(DESC, "Target Time")
   field(EGU, "ns")

--- a/app/srcProtocol/TEM_PhaseLock.proto
+++ b/app/srcProtocol/TEM_PhaseLock.proto
@@ -14,6 +14,8 @@ GET_BUILD           { out "Build=";               in "Build= %s";}
 # Monitoring
 GET_REGOUT_A        { out "RegOutA=";             in "RegOutA= %i";}
 GET_REGOUT_B        { out "RegOutB=";             in "RegOutB= %i";}
+GET_OUT_A           { out "OutputA=";             in "OutputA= %i";}
+GET_OUT_B           { out "OutputB=";             in "OutputB= %i";}
 GET_PHASE           { out "Phase=";               in "Phase= %i";}
 GET_PHASE_SP        { out "SetPointPhase=";       in "SetPointPhase= %i";}
 GET_ERROR           { out "Error=";               in "Error= %i";}

--- a/app/srcProtocol/TEM_PhaseLock.proto
+++ b/app/srcProtocol/TEM_PhaseLock.proto
@@ -8,8 +8,9 @@ WriteTimeout  =  10000;
 ExtraInput    =  Ignore;
 
 # System
-GET_SERIAL          { out "Serial=";              in "Serial= %s";}
+GET_SERIAL          { out "SerialNumber=";        in "SerialNumber= %s";}
 GET_BUILD           { out "Build=";               in "Build= %s";}
+GET_FPGA            { out "FPGAFirmware=";        in "FPGAFirmware= %s";}
 
 # Monitoring
 GET_REGOUT_A        { out "RegOutA=";             in "RegOutA= %i";}

--- a/screens/TEM_PhaseLock.ui
+++ b/screens/TEM_PhaseLock.ui
@@ -218,7 +218,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -256,7 +256,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -334,7 +334,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -372,7 +372,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -532,7 +532,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -608,7 +608,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -639,7 +639,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -684,7 +684,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -760,7 +760,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -791,7 +791,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -867,7 +867,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -960,7 +960,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -991,7 +991,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1060,7 +1060,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1098,7 +1098,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1141,7 +1141,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1172,7 +1172,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1248,7 +1248,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1293,7 +1293,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1362,7 +1362,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1524,7 +1524,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1555,7 +1555,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1586,7 +1586,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1638,7 +1638,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1681,7 +1681,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1788,7 +1788,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1879,7 +1879,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -1924,7 +1924,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -2024,7 +2024,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>

--- a/screens/TEM_PhaseLock.ui
+++ b/screens/TEM_PhaseLock.ui
@@ -450,339 +450,11 @@
      <x>20</x>
      <y>200</y>
      <width>408</width>
-     <height>311</height>
+     <height>312</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <item row="6" column="0">
-     <widget class="QLabel" name="label_18">
-      <property name="text">
-       <string>Reg Out Range A</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_STATE</string>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_IGAIN</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_9">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:ERR_SCALE_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_STATE</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="0">
-     <widget class="QLabel" name="label_21">
-      <property name="text">
-       <string>Reg A D Gain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="label_17">
-      <property name="text">
-       <string>Reg A Offset</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_12">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_LOCKED</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_15">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_OFFSET_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0">
-     <widget class="QLabel" name="label_16">
-      <property name="text">
-       <string>Reg A On/Off</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_10">
-      <property name="text">
-       <string>Error Scale</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_19">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_DGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_9">
-      <property name="text">
-       <string>Reg On/Off</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_PGAIN</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_15">
-      <property name="text">
-       <string>Reg Out A</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_14">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_STATE_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
+    <item row="7" column="1">
      <widget class="PyDMLabel" name="PyDMLabel_16">
       <property name="toolTip">
        <string/>
@@ -813,14 +485,14 @@
       </property>
      </widget>
     </item>
-    <item row="8" column="0">
-     <widget class="QLabel" name="label_20">
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_10">
       <property name="text">
-       <string>Reg A I Gain</string>
+       <string>Error Scale</string>
       </property>
      </widget>
     </item>
-    <item row="6" column="2">
+    <item row="7" column="2">
      <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
       <property name="toolTip">
        <string/>
@@ -858,39 +530,15 @@
       </property>
      </widget>
     </item>
-    <item row="7" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_17">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_PGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
+    <item row="5" column="0">
+     <widget class="QLabel" name="label_16">
+      <property name="text">
+       <string>Reg A On/Off</string>
       </property>
      </widget>
     </item>
-    <item row="1" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+    <item row="8" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
       <property name="toolTip">
        <string/>
       </property>
@@ -916,38 +564,7 @@
        <bool>false</bool>
       </property>
       <property name="channel" stdset="0">
-       <string>ca://${BASE}:ERR_SCALE</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_DGAIN</string>
+       <string>ca://${BASE}:REG_A_PGAIN</string>
       </property>
      </widget>
     </item>
@@ -982,72 +599,17 @@
       </property>
      </widget>
     </item>
-    <item row="8" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_18">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_IGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
+    <item row="10" column="0">
+     <widget class="QLabel" name="label_21">
+      <property name="text">
+       <string>Reg A D Gain</string>
       </property>
      </widget>
     </item>
     <item row="7" column="0">
-     <widget class="QLabel" name="label_19">
+     <widget class="QLabel" name="label_18">
       <property name="text">
-       <string>Reg A P Gain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_A_OFFSET</string>
+       <string>Reg Out Range A</string>
       </property>
      </widget>
     </item>
@@ -1082,14 +644,452 @@
       </property>
      </widget>
     </item>
-    <item row="10" column="0">
+    <item row="6" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_OFFSET</string>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_18">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_IGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_STATE</string>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="0">
+     <widget class="QLabel" name="label_20">
+      <property name="text">
+       <string>Reg A I Gain</string>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="0">
+     <widget class="QLabel" name="label_19">
+      <property name="text">
+       <string>Reg A P Gain</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_STATE</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:ERR_SCALE</string>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_19">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_DGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_17">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_PGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_9">
+      <property name="text">
+       <string>Reg On/Off</string>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="0">
      <widget class="QLabel" name="label_34">
       <property name="text">
        <string>Reg A Error Means</string>
       </property>
      </widget>
     </item>
-    <item row="10" column="1">
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_15">
+      <property name="text">
+       <string>Reg Out A</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QLabel" name="label_17">
+      <property name="text">
+       <string>Reg A Offset</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_12">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_LOCKED</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_15">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_OFFSET_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="10" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_DGAIN</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_9">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:ERR_SCALE_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_14">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_STATE_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_A_IGAIN</string>
+      </property>
+     </widget>
+    </item>
+    <item row="11" column="1">
      <widget class="PyDMLabel" name="PyDMLabel_32">
       <property name="toolTip">
        <string/>
@@ -1120,6 +1120,44 @@
       </property>
      </widget>
     </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="label_35">
+      <property name="text">
+       <string>Output A</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_33">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:OUTPUT_A</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QWidget" name="gridLayoutWidget_2">
@@ -1132,8 +1170,8 @@
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_2">
-    <item row="3" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_23">
+    <item row="9" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_31">
       <property name="toolTip">
        <string/>
       </property>
@@ -1156,200 +1194,17 @@
        <string/>
       </property>
       <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_OFFSET_RBCK</string>
+       <string>ca://${BASE}:REG_B_ERROR_MEANS</string>
       </property>
       <property name="enableRichText" stdset="0">
        <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_21">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_IGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_OFFSET</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_28">
-      <property name="text">
-       <string>Reg Out B</string>
       </property>
      </widget>
     </item>
     <item row="6" column="0">
-     <widget class="QLabel" name="label_25">
+     <widget class="QLabel" name="label_26">
       <property name="text">
-       <string>Reg B I Gain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_26">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_PGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_22">
-      <property name="text">
-       <string>Reg B Offset</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="0">
-     <widget class="QLabel" name="label_29">
-      <property name="text">
-       <string>Reg B D Gain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_22">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_OUT_B_RANGE_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_27">
-      <property name="text">
-       <string>Reg B On/Off</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_PGAIN</string>
+       <string>Reg B P Gain</string>
       </property>
      </widget>
     </item>
@@ -1385,68 +1240,6 @@
      </widget>
     </item>
     <item row="7" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_16">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_DGAIN</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_14">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_OUT_B_RANGE</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="2">
      <widget class="PyDMLineEdit" name="PyDMLineEdit_10">
       <property name="toolTip">
        <string/>
@@ -1477,14 +1270,52 @@
       </property>
      </widget>
     </item>
-    <item row="5" column="0">
-     <widget class="QLabel" name="label_26">
+    <item row="8" column="0">
+     <widget class="QLabel" name="label_29">
       <property name="text">
-       <string>Reg B P Gain</string>
+       <string>Reg B D Gain</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="2">
+    <item row="6" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_PGAIN</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="label_22">
+      <property name="text">
+       <string>Reg B Offset</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="2">
      <widget class="PyDMLineEdit" name="PyDMLineEdit_11">
       <property name="toolTip">
        <string/>
@@ -1512,6 +1343,213 @@
       </property>
       <property name="channel" stdset="0">
        <string>ca://${BASE}:REG_B_STATE</string>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_26">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_PGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_22">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_OUT_B_RANGE_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="9" column="0">
+     <widget class="QLabel" name="label_33">
+      <property name="text">
+       <string>Reg B Error Means</string>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_21">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_IGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_24">
+      <property name="text">
+       <string>Locked B</string>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_27">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_DGAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_OFFSET</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_14">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_OUT_B_RANGE</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_28">
+      <property name="text">
+       <string>Reg Out B</string>
       </property>
      </widget>
     </item>
@@ -1546,7 +1584,69 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="1">
+    <item row="8" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_16">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_DGAIN</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_23">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:REG_B_OFFSET_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
      <widget class="PyDMLabel" name="PyDMLabel_20">
       <property name="toolTip">
        <string/>
@@ -1577,60 +1677,36 @@
       </property>
      </widget>
     </item>
-    <item row="7" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_27">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_DGAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_24">
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_27">
       <property name="text">
-       <string>Locked B</string>
+       <string>Reg B On/Off</string>
       </property>
      </widget>
     </item>
-    <item row="4" column="0">
+    <item row="7" column="0">
+     <widget class="QLabel" name="label_25">
+      <property name="text">
+       <string>Reg B I Gain</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="0">
      <widget class="QLabel" name="label_23">
       <property name="text">
        <string>Reg Out Range B</string>
       </property>
      </widget>
     </item>
-    <item row="8" column="0">
-     <widget class="QLabel" name="label_33">
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_36">
       <property name="text">
-       <string>Reg B Error Means</string>
+       <string>Output B</string>
       </property>
      </widget>
     </item>
-    <item row="8" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_31">
+    <item row="2" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_34">
       <property name="toolTip">
        <string/>
       </property>
@@ -1653,7 +1729,7 @@
        <string/>
       </property>
       <property name="channel" stdset="0">
-       <string>ca://${BASE}:REG_B_ERROR_MEANS</string>
+       <string>ca://${BASE}:OUTPUT_B</string>
       </property>
       <property name="enableRichText" stdset="0">
        <bool>false</bool>

--- a/screens/TEM_PhaseLock.ui
+++ b/screens/TEM_PhaseLock.ui
@@ -450,7 +450,7 @@
      <x>20</x>
      <y>200</y>
      <width>408</width>
-     <height>312</height>
+     <height>328</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -1166,7 +1166,7 @@
      <x>470</x>
      <y>250</y>
      <width>408</width>
-     <height>261</height>
+     <height>270</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_2">
@@ -1942,55 +1942,10 @@
      <x>470</x>
      <y>567</y>
      <width>403</width>
-     <height>101</height>
+     <height>102</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_4">
-    <item row="1" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_28">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>0</number>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="alarmSensitiveContent" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="alarmSensitiveBorder" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="PyDMToolTip" stdset="0">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${BASE}:QI_GAIN_RBCK</string>
-      </property>
-      <property name="enableRichText" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_31">
-      <property name="text">
-       <string>QI Gain</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_30">
-      <property name="text">
-       <string>QI Active</string>
-      </property>
-     </widget>
-    </item>
     <item row="0" column="1">
      <widget class="PyDMLabel" name="PyDMLabel_29">
       <property name="toolTip">
@@ -2019,6 +1974,13 @@
       </property>
       <property name="enableRichText" stdset="0">
        <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_32">
+      <property name="text">
+       <string>QI Offset</string>
       </property>
      </widget>
     </item>
@@ -2053,6 +2015,37 @@
       </property>
      </widget>
     </item>
+    <item row="1" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_28">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:QI_GAIN_RBCK</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="2">
      <widget class="PyDMLineEdit" name="PyDMLineEdit_22">
       <property name="toolTip">
@@ -2084,10 +2077,48 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_32">
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_31">
       <property name="text">
-       <string>QI Offset</string>
+       <string>QI Gain</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="2">
+     <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="monitorDisp" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:QI_OFFSET</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_30">
+      <property name="text">
+       <string>QI Active</string>
       </property>
      </widget>
     </item>
@@ -2122,8 +2153,15 @@
       </property>
      </widget>
     </item>
-    <item row="2" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_37">
+      <property name="text">
+       <string>QI Offset</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_35">
       <property name="toolTip">
        <string/>
       </property>
@@ -2131,7 +2169,7 @@
        <number>0</number>
       </property>
       <property name="showUnits" stdset="0">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>true</bool>
@@ -2145,11 +2183,11 @@
       <property name="PyDMToolTip" stdset="0">
        <string/>
       </property>
-      <property name="monitorDisp" stdset="0">
-       <bool>false</bool>
-      </property>
       <property name="channel" stdset="0">
-       <string>ca://${BASE}:QI_OFFSET</string>
+       <string>ca://${BASE}:QI_OFFSET_RBCK_PS</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
       </property>
      </widget>
     </item>

--- a/screens/TEM_PhaseLock.ui
+++ b/screens/TEM_PhaseLock.ui
@@ -450,7 +450,7 @@
      <x>20</x>
      <y>200</y>
      <width>408</width>
-     <height>328</height>
+     <height>311</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -1166,7 +1166,7 @@
      <x>470</x>
      <y>250</y>
      <width>408</width>
-     <height>270</height>
+     <height>261</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_2">
@@ -1942,7 +1942,7 @@
      <x>470</x>
      <y>567</y>
      <width>403</width>
-     <height>102</height>
+     <height>108</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_4">

--- a/screens/TEM_PhaseLock.ui
+++ b/screens/TEM_PhaseLock.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>908</width>
-    <height>691</height>
+    <height>742</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>20</x>
      <y>90</y>
      <width>211</width>
-     <height>52</height>
+     <height>71</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="formLayout">
@@ -99,6 +99,44 @@
       </property>
      </widget>
     </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_38">
+      <property name="text">
+       <string>FPGA FW</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="PyDMLabel" name="PyDMLabel_36">
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="precision" stdset="0">
+       <number>0</number>
+      </property>
+      <property name="showUnits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="alarmSensitiveContent" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="PyDMToolTip" stdset="0">
+       <string/>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${BASE}:FPGAFW</string>
+      </property>
+      <property name="enableRichText" stdset="0">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QLabel" name="label">
@@ -127,7 +165,7 @@
      <x>10</x>
      <y>50</y>
      <width>231</width>
-     <height>101</height>
+     <height>121</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -286,7 +324,7 @@
      <x>250</x>
      <y>50</y>
      <width>641</width>
-     <height>101</height>
+     <height>121</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -400,9 +438,9 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>160</y>
+     <y>183</y>
      <width>881</width>
-     <height>361</height>
+     <height>381</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -428,7 +466,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>170</y>
+     <y>193</y>
      <width>121</width>
      <height>16</height>
     </rect>
@@ -448,9 +486,9 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>200</y>
+     <y>223</y>
      <width>408</width>
-     <height>311</height>
+     <height>328</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -1164,9 +1202,9 @@
    <property name="geometry">
     <rect>
      <x>470</x>
-     <y>250</y>
+     <y>273</y>
      <width>408</width>
-     <height>261</height>
+     <height>270</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout_2">
@@ -1742,7 +1780,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>570</y>
+     <y>615</y>
      <width>403</width>
      <height>61</height>
     </rect>
@@ -1892,7 +1930,7 @@
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>530</y>
+     <y>575</y>
      <width>881</width>
      <height>151</height>
     </rect>
@@ -1920,7 +1958,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>540</y>
+     <y>585</y>
      <width>121</width>
      <height>16</height>
     </rect>
@@ -1940,7 +1978,7 @@
    <property name="geometry">
     <rect>
      <x>470</x>
-     <y>567</y>
+     <y>612</y>
      <width>403</width>
      <height>108</height>
     </rect>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A few clean up tasks and some new PVs to help make this IOC a bit more usable. Summary:
- Fix unit displays on the GUI
- Add a QI Offset calculation in ps
- Add output regulator A/B RBVs
- Fix broken FW/serial number readbacks
- Add in FPGA FW version PV

## Motivation and Context
Closes #2 

## How Has This Been Tested?
Tested live in the fiber timing lab. 

## Where Has This Been Documented?
The code and this PR. 


## Screenshots:
Old Screen: 
![image](https://github.com/user-attachments/assets/4f56a9a9-9143-443b-a529-4db9188209d0)

New Screen: 
![image](https://github.com/user-attachments/assets/a370e470-7878-4c73-ab18-6d669d413747)



## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
